### PR TITLE
feat: bump jq to 1.7.1 and replace deprecated use of set-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# setup-yq-action
-GitHub Action to setup the `jq` and `yq` command for yaml and json parsing
-
+# setup-jq-action
+GitHub Action to setup the `jq` command for json parsing
 
 Example of use :
 ```yaml
@@ -10,15 +9,15 @@ on: [ "push" ]
 
 jobs:
   parse_yaml:
-    name: Parse Yaml
+    name: Parse JSON
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install yq
-        id: setup-yq
-        uses: shiipou/setup-yq-action@v2.0.1
+      - name: Install jq
+        id: setup-jq
+        uses: urgn/setup-jq-action@v3.0.2
       - name: get version
         run: |
-          VERSION=$(${{ steps.setup-yq.outputs.yq-binary }} '.dependency.my_component.git.ref' pubspec.yaml)
+          VERSION=$(${{ steps.setup-jq.outputs.jq-binary }} '.dependency.my_component.git.ref' pubspec.json)
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -17,4 +17,4 @@ runs:
         mkdir -p ${HOME}/.local/bin
         wget https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 -O ${HOME}/.local/bin/jq
         chmod +x ${HOME}/.local/bin/jq
-        echo "::set-output name=jq-binary::${HOME}/.local/bin/jq"
+        echo "jq-binary=${HOME}/.local/bin/jq" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,6 @@ runs:
       shell: bash
       run: |
         mkdir -p ${HOME}/.local/bin
-        wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O ${HOME}/.local/bin/jq
+        wget https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 -O ${HOME}/.local/bin/jq
         chmod +x ${HOME}/.local/bin/jq
         echo "::set-output name=jq-binary::${HOME}/.local/bin/jq"

--- a/action.yaml
+++ b/action.yaml
@@ -4,7 +4,7 @@ author: 'urgn'
 
 outputs:
   jq-binary:
-    description: 'The pinary path for the jq command'
+    description: 'The binary path for the jq command'
     value: ${{ steps.install-jq.outputs.jq-binary }}
     
 runs:


### PR DESCRIPTION
Hello @urgn ,

I've added a few changes in your action:
- bump jq to [1.7.1](https://github.com/jqlang/jq/releases/tag/jq-1.7.1)
- replace deprecated use of set-output (as recommended by [github](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
- fix example and description in README

Let me know if you have any comment.

And thanks for maintaining this github action.